### PR TITLE
Resolve issue with google drive realtime api entities containing read-only properties

### DIFF
--- a/addon/adapters/adapter.js
+++ b/addon/adapters/adapter.js
@@ -6,12 +6,17 @@ import ChangeObserver from 'ember-gdrive/lib/change-observer';
 
 import { modelKey } from 'ember-gdrive/lib/util';
 
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
 var Adapter = DS.Adapter.extend({
   defaultSerializer: '-google-drive',
 
   documentSource: null,
   document: Ember.computed.alias('documentSource.document'),
   namespace: 'v1',
+  
 
   ref: function() {
     var ref = this.get('document.ref'),
@@ -21,10 +26,10 @@ var Adapter = DS.Adapter.extend({
   }.property('document.ref', 'namespace'),
 
   recordCreatedRemotely: function(store, typeKey, data) {
-    store.push(typeKey, data);
+    store.push(typeKey, clone(data));
   },
   recordUpdatedRemotely: function(store, typeKey, data) {
-    store.push(typeKey, data);
+    store.push(typeKey, clone(data));
   },
   recordDeletedRemotely: function(store, typeKey, id) {
     var deletedRecord = store.getById(typeKey, id);
@@ -32,10 +37,10 @@ var Adapter = DS.Adapter.extend({
   },
 
   recordCreatedLocally: function(store, typeKey, data) {
-    store.push(typeKey, data);
+    store.push(typeKey, clone(data));
   },
   recordUpdatedLocally: function(store, typeKey, data, e) {
-    store.push(typeKey, data);
+    store.push(typeKey, clone(data));
   },
   recordDeletedLocally: function(store, typeKey, id) {
     var deletedRecord = store.getById(typeKey, id);
@@ -62,7 +67,7 @@ var Adapter = DS.Adapter.extend({
 
   find: function(store, type, id) {
     this.observeRecordData(store, type.typeKey, id);
-    return Ember.RSVP.resolve( this.get('ref').get(modelKey(type), id).value() );
+    return Ember.RSVP.resolve(clone(this.get('ref').get(modelKey(type), id).value()));
   },
 
   createRecord: function(store, type, record) {
@@ -76,7 +81,7 @@ var Adapter = DS.Adapter.extend({
 
     this.observeRecordData(store, type.typeKey, id);
 
-    return Ember.RSVP.resolve( this.get('ref').get(modelKey(type), id).value() );
+    return Ember.RSVP.resolve( clone(this.get('ref').get(modelKey(type), id).value()) );
   },
 
   updateRecord: function(store, type, record) {
@@ -90,13 +95,13 @@ var Adapter = DS.Adapter.extend({
 
     this.observeRecordData(store, type.typeKey, id);
 
-    return Ember.RSVP.resolve( ref.get(modelKey(type), id).value() );
+    return Ember.RSVP.resolve( clone(ref.get(modelKey(type), id).value()) );
   },
 
   findAll: function(store, type) {
     var adapter = this,
         ref = this.get('ref'),
-        identityMap = ref.get(modelKey(type)).value() || {},
+        identityMap = clone(ref.get(modelKey(type)).value() || {}),
         keys = ref.get(modelKey(type)).keys(),
         serializedRecords = [];
 


### PR DESCRIPTION
Should resolve #18.
# Issue

The way our ember-gdrive adapter now works is that it simply uses the object gapi returns to us, and it looks like some of that object's properties are now read only. 

For a `hasMany` relationship, we overwrite the property containing a reference to a related item (for instance, widget property) with the actual value of the item. This is what throws an error.
# Solution (for now)

The (temporary) solution I've implemented is to execute `JSON.parse(JSON.stringify(entity))` on each entity retrieved from google's API. I've added a `clone` method to to adapter script and I'm calling it every time we're pushing an entity retrieved from `gapi` to the store. It's not ideal, but it allows me to continue work on Storypad until we figure out a proper solution.

I was hoping the adapter's `serialize` method would be the perfect hook to insert cloning into, but apparently, it's not. It simply isn't called at the proper time. Push is a store method, so I can't really write an override for that either: http://emberjs.com/api/data/classes/DS.Adapter.html#method_serialize

Perhaps adding a basic custom serializer would work?

There's also the question of a proper cloning method. JSON.parse(JSON.stringify(value)) works, but it's pretty much a hack. Any chance ember contains some helper clone method somewhere?
