### PR TITLE
Fixed issue with app config being inaccessible from "addon" folder

### DIFF
--- a/addon/lib/config.js
+++ b/addon/lib/config.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+var Config = Ember.Object.extend({
+  GOOGLE_API_KEY: null,
+  GOOGLE_MIME_TYPE: null,
+  GOOGLE_DRIVE_SDK_APP_ID: null,
+  GOOGLE_CLIENT_ID: null,
+  
+  load: function (configuration) {
+    this.set('GOOGLE_API_KEY', configuration.GOOGLE_API_KEY);
+    this.set('GOOGLE_MIME_TYPE', configuration.GOOGLE_MIME_TYPE);
+    this.set('GOOGLE_DRIVE_SDK_APP_ID', configuration.GOOGLE_DRIVE_SDK_APP_ID);
+    this.set('GOOGLE_CLIENT_ID', configuration.GOOGLE_CLIENT_ID);
+  }
+});
+
+export default Config.create();

--- a/addon/lib/picker.js
+++ b/addon/lib/picker.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-import Config from '../config/environment';
+import config from 'ember-gdrive/lib/config';
 
 export default Ember.Object.extend(Ember.Evented, {
   token: null,
-  apiKey: Config['ember-gdrive'].GOOGLE_API_KEY,
-  mimeTypes: Config['ember-gdrive'].GOOGLE_MIME_TYPE,
+  apiKey: config.get('GOOGLE_API_KEY'),
+  mimeTypes: config.get('GOOGLE_MIME_TYPE'),
 
   show: function() {
     this.get('googlePicker').setVisible(true);

--- a/addon/lib/share-dialog.js
+++ b/addon/lib/share-dialog.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-import Config from '../config/environment';
+import config from 'ember-gdrive/lib/config';
 
 export default Ember.Object.extend({
   documentId: Ember.required(),
   show: function() {
-    var shareClient = new gapi.drive.share.ShareClient(Config['ember-gdrive'].GOOGLE_DRIVE_SDK_APP_ID);
+    var shareClient = new gapi.drive.share.ShareClient(config.get('GOOGLE_DRIVE_SDK_APP_ID'));
 
     shareClient.setItemIds([ this.get('documentId') ]);
     shareClient.showSettingsDialog();

--- a/app/authenticators/gdrive.js
+++ b/app/authenticators/gdrive.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import Base from 'simple-auth/authenticators/base';
 import Auth from 'ember-gdrive/lib/auth';
 import Cache from 'ember-gdrive/lib/local-cache';
-import Config from '../config/environment';
+import config from 'ember-gdrive/lib/config';
 
 var Authenticator = Base.extend({
   
@@ -14,7 +14,7 @@ var Authenticator = Base.extend({
     var authenticator = this;
     return authenticator.get('auth').authorizeImmediate({
       login_hint: this.inferUserId(),
-      client_id: Config['ember-gdrive'].GOOGLE_CLIENT_ID
+      client_id: config.get('GOOGLE_CLIENT_ID')
     }).then(function () {
       return authenticator.get('auth').fetchCurrentUser();
     });
@@ -22,7 +22,7 @@ var Authenticator = Base.extend({
 
   authenticate: function (options) {
     var authenticator = this;
-    return authenticator.get('auth').authorize(Ember.merge(options, { client_id: Config['ember-gdrive'].GOOGLE_CLIENT_ID })).then(function () {
+    return authenticator.get('auth').authorize(Ember.merge(options, { client_id: config.get('GOOGLE_CLIENT_ID') })).then(function () {
       return authenticator.get('auth').fetchCurrentUser();
     });
   },

--- a/app/initializers/load-config.js
+++ b/app/initializers/load-config.js
@@ -1,0 +1,12 @@
+import config from 'ember-gdrive/lib/config';
+
+export default {
+  name: 'load-config',
+  before: 'simple-auth',
+
+  initialize: function(container, app) {
+
+    //get you setting off of the app instance
+    config.load(app.get('ember-gdrive'));    
+  }
+};


### PR DESCRIPTION
This fixes #24.

Apparently, there was some caching issue when implementing #22, because after a system restart, an error was being thrown in 
- addon/lib/picker.js
- addon/lib/share-dialog.js

It turns out that for addons inside the "app" folder of the addon, relative paths such as

```
../config/environment
```

translate to 

```
[appname]/config/environment
```

However, the exact same relative path used in a script placed inside the "addon" folder of the addon translates to

```
[addonname]/config/environment
```

Because of that, the above two libraries were throwing a file-not-found error.

The solution is to create an initializer which then either injects the required config properties via `app.register/app.inject`, or it stores it somewhere for us to access later.

Since we require these config properties from inside regular libraries, I decided to go with a "singleton" route. I've created `addon/lib/config.js`. This is a module that exports an instance of an `Ember.object`, so it acts as a singleton. `app/initializers/load-config` is an initializer that runs before the `simple-auth` initializer. It loads the config properties into our singleton, so all other scripts can easily access it leader.

However, this **requires another change inside storypad**.

This is how our initializer function looks like:

```
initialize: function(container, app) {
  //get you setting off of the app instance
  config.load(app.get('ember-gdrive'));    
}
```

The `app` object contains all properties defined inside the `APP` object of `[appname]/config/environment.js` and this is the only thing that's really easily accessible from inside an ember-cli addon.  Basically, the expected way for us to share settings with an addon in an ember-cli application is to put those settings inside the `APP` object. 

`ember-cli-simple-auth` doesn't do this because they never make use of the addon folder, so everything they have is contained within the "app" folder. For them, relative paths work just as well, but for us, that has an unfortunate consequence of messing up the config/environment script a bit - `ember-gdrive` options are now in `ENV.APP`, while `simple-auth` options remain in `ENV`.

In my opinion, **we should look into somehow removing the `simple-auth` options from config/environment completely**. They are tied to the addon we're using simple-auth from, so they should be unchangeable anyway.

http://stackoverflow.com/a/25631098 explains part of this.
