### PR TITLE
Fixed "ENV is undefined" issue in addon/lib/document

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import Reference from 'ember-gdrive/lib/reference';
+import config from 'ember-gdrive/lib/config';
 
 var Document = Ember.Object.extend(Ember.Evented, {
   id: null,
@@ -177,7 +178,7 @@ Document.reopenClass({
     return new Ember.RSVP.Promise(function(resolve, reject) {
       gapi.client.drive.files.insert({
         'resource': {
-          mimeType: ENV.GOOGLE_MIME_TYPE,
+          mimeType: config.get('GOOGLE_MIME_TYPE'),
           title: Ember.get(params, 'title')
         }
       }).execute(function(d){ Ember.run(null, resolve, d); });


### PR DESCRIPTION
Resolves #31.

A simple matter of switching to using the `config` object instead of relying on a global `ENV` variable. Part of #14, but was missed when resolving that task.
