### PR TITLE
Move google-drive-permission model and adapter to ember-gdrive

### DIFF
--- a/app/adapters/google-drive-permission.js
+++ b/app/adapters/google-drive-permission.js
@@ -1,0 +1,69 @@
+/*global gapi*/
+import Ember from 'ember';
+import DS from 'ember-data';
+
+var Adapter = DS.Adapter.extend({
+
+  documentSource: null,
+  documentId: Ember.computed.alias('documentSource.document.id'),
+
+  createRecord: function (store, type, record) {
+
+    var options = {
+      resource: {
+        value: record.get('emailAddress'),
+        type: record.get('type'),
+        role: record.get('role')
+      },
+      fileId: this.get('documentId'),
+      sendNotificationEmails: false
+    };
+
+    var request = gapi.client.drive.permissions.insert(options);
+
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      request.execute(function (response) {
+        if (response.error) {
+          Ember.run(null, reject, response.error);
+        } else {
+          Ember.run(null, resolve, response);
+        }
+      });
+    });
+  },
+
+  deleteRecord: function (store, type, record) {
+    var request = gapi.client.drive.permissions.delete({
+      fileId: this.get('documentId'),
+      permissionId: record.get('id')
+    });
+
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      request.execute(function (response) {
+        if (response.error) {
+          Ember.run(null, reject, response.error);
+        } else {
+          Ember.run(null, resolve, null);
+        }
+      });
+    });
+  },
+
+  findAll: function (store, type) {
+    var request = gapi.client.drive.permissions.list({
+      fileId: this.get('documentId')
+    });
+
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      request.execute(function (response) {
+        if (response.error) {
+          Ember.run(null, reject, response.error);
+        } else {
+          Ember.run(null, resolve, response.items);
+        }
+      });
+    });
+  }
+});
+
+export default Adapter;

--- a/app/models/google-drive-permission.js
+++ b/app/models/google-drive-permission.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+var GoogleDrivePermission = DS.Model.extend({
+  domain: DS.attr('string'),
+  emailAddress: DS.attr('string'),
+  etag: DS.attr('string'),
+  kind: DS.attr('string'),
+  name: DS.attr('string'),
+  photoLink: DS.attr('string'),
+  role: DS.attr('string'),
+  selfLink: DS.attr('string'),
+  type: DS.attr('string')
+});
+
+export default GoogleDrivePermission;


### PR DESCRIPTION
Part of a solution to #36 

Resolves #40

# First step - this pull request

The first step is to move
* `storypad\adapters\google-drive-permission.js`
* `storypad\models\google-drive-permission.js`

into
* `ember-gdrive\app\adapters\google-drive-permission.js`
* `ember-gdrive\app\models\google-drive-permission.js`

This doesn't change the behavior of storypad at all, because with Ember CLI addons, anything inside the addon's "app" folder get's merged with the app using the addon.

# Next step

The next stap is major.

The share-modal should probably be transformed into a component and also moved into ember-gdrive.

If we do it properly, we can implement the modal so it allows for custom layouts and styles, with the background logic still abstracted inside the addon.  Ann approach similar to what **ic-modal** uses could work - https://github.com/instructure/ic-modal.

If we implement a modal component like that, we can also move
* `ember-gdrive\app\adapters\google-drive-permission.js`
* `ember-gdrive\app\models\google-drive-permission.js`

into
* `ember-gdrive\addon\adapters\google-drive-permission.js`
* `ember-gdrive\addon\models\google-drive-permission.js`

This would make them private, so the addon's interface with the app would be only the modal component.

# Final step

The final step would be to implement the option to send custom e-mails with the share action. For that, the addon would require a couple of configuration settings to be provided by the app (via the already established `[appname]/config/environment/env/app['ember-gdrive']` configuration object. 

I think that in this case, the addon's user would provide the e-mail service endpoint address via the config, as well as the content of the e-mail via a method call (or in some other way).

@venkatd: In my opinion, this pull request should be merged as is, with the second and third step each having their own task and pull request. There would also be a related task/pull-request inside venkatd/storypad. This would mean that this is ready for merge.