### PR TITLE
Moved share-modal component from storypad into ember-gdrive

### DIFF
--- a/app/components/share-modal.js
+++ b/app/components/share-modal.js
@@ -1,0 +1,95 @@
+/*global gapi, alert, confirm*/
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'share-modal',
+  classNames: ['share-modal-wrapper'],
+  classNameBindings: ['isOpen:open'],
+  
+  shareAddress: null,
+  isOpen: false,
+
+  onOpening: function () {
+    this.loadData();
+  }.on('willOpen'),
+
+  onClosing: function () {
+    this.set('shareAddress', null);
+  }.on('willClose'),
+
+  closeOnClick: function (event) {
+    if (event.target === this.get('element')) {
+      this.close();
+    }
+  }.on('click'),
+
+  open: function () {
+    this.trigger('willOpen');
+    this.set('isOpen', true);
+  },
+
+  close: function () {
+    this.trigger('willClose');
+    this.set('isOpen', false);
+  },
+
+  'open-when': false,
+
+  openWhen: function () {
+    if (!this.get('open-when')) {
+      return;
+    }
+    this.open();
+    this.set('open-when', false);
+  }.observes('open-when'),
+
+  actions: {
+
+    share: function () {
+      this.share();
+    },
+
+    removePermission: function (permission) {
+      this.removePermission(permission);
+    },
+
+    close: function () {
+      this.close();
+    }
+  },
+
+  loadData: function () {
+    var component = this,
+      store = component.get('targetObject.store');
+    store.unloadAll('google-drive-permission');
+    store.find('google-drive-permission').then(function (permissions) {
+      component.set('permissions', permissions);
+    });
+  },
+
+  share: function () {
+    var component = this;
+    var permission = component.get('targetObject.store').createRecord('google-drive-permission', {
+      emailAddress: this.get('shareAddress'),
+      type: 'user', // user, group, domain, anyone
+      role: 'writer' // owner, reader, writer
+    });
+    permission.save().then(function () {
+      component.set('shareAddress', null);
+    }, function (error) {
+      permission.rollback();
+      alert(error.message);
+    });
+  },
+
+  removePermission: function (permission) {
+    var component = this;
+    if (confirm('Are you sure?')) {
+      permission.deleteRecord();
+      permission.save().then(null, function (error) {
+        permission.rollback();
+        Ember.run.once(component, component.loadData, null);
+      });
+    }
+  },
+});

--- a/app/templates/components/share-modal.hbs
+++ b/app/templates/components/share-modal.hbs
@@ -1,0 +1,28 @@
+{{#if isOpen}}
+  <div class="share-modal">
+
+    <div class="share-modal-head">
+      <h1>Share document</h1>
+    </div>
+
+    <div class="share-modal-body">
+      <h1>Users with access to document</h1>
+      <ul>
+        {{#each permission in permissions}}
+        <li><a {{action 'removePermission' permission}}>{{#if permission.name}}{{permission.name}} {{permission.emailAddress}}{{else}}{{permission.emailAddress}}{{/if}}</a>
+        </li>
+        {{/each}}
+      </ul>
+
+      <h1>Share with more users</h1>
+      <form action 'share' on="submit">
+        {{input placeholder="Type e-mail" value=shareAddress }}
+        <input type="submit" value="Share" {{action 'share'}}/>
+      </form>
+    </div>
+
+    <div class="share-modal-footer">
+      <button {{action 'close'}} class="button regular">Close</button>
+    </div>
+  </div>
+{{/if}}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
 module.exports = {
-  name: 'ember-gdrive'
+  name: 'ember-gdrive',
+  included: function (app) {
+    app.import('vendor/share-modal.css');
+  }
 };

--- a/vendor/share-modal.css
+++ b/vendor/share-modal.css
@@ -1,0 +1,92 @@
+.share-modal-wrapper {
+  position: fixed;
+  display: none;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 999999;
+}
+
+.share-modal-wrapper.open{
+  display: flex;
+}
+
+.share-modal {
+  width: 500px;
+  //min-height: 300px;
+  overflow:hidden;
+  background-color: #FFF;
+  border: 1px solid #DDD;
+  -webkit-border-radius: 5px;
+     -moz-border-radius: 5px;
+      -ms-border-radius: 5px;
+          border-radius: 5px;
+  box-shadow: 2px 2px 5px #ddd;
+}
+
+.share-modal .share-modal-head{
+  padding: 10px;
+  border-bottom: 1px solid #DDD;
+  //background-color: $brand-light;
+}
+
+.share-modal .share-modal-body {
+  padding: 10px;
+  min-height:200px;
+}
+
+.share-modal .share-modal-body ul {
+  margin-left: -10px;
+}
+
+.share-modal .share-modal-body ul li {
+  color: #333;
+  display: inline-block;
+  margin: 10px;
+  border: 1px solid #DDD;
+  padding: 10px;
+  box-sizing:border-box;
+  text-align: center;        
+}
+
+.share-modal .share-modal-body form {
+  margin: 10px 0;
+}
+
+.share-modal .share-modal-body form input {
+  margin: 10px 0;
+  display: inline-block;
+}
+
+.share-modal .share-modal-body form input[type=submit] {
+  margin-left: 10px;
+  width: 100px;
+}
+
+.share-modal .share-modal-body form input[type=text] {
+  width: calc(100% - 120px);
+}
+
+.share-modal .share-modal-footer {
+  padding:10px;
+  border-top: 1px solid #DDD;
+  background:#f4f4f4;
+}
+
+.share-modal .share-modal-footer .button {
+  float:right;
+  margin: 0;
+}
+
+.share-modal .share-modal-footer:before,
+.share-modal .share-modal-footer:after {
+    content: '';
+    display: table;
+}
+.share-modal .share-modal-footer:after {
+    clear: both;
+}


### PR DESCRIPTION
Part of a solution for #36. Resolves #46. Related to venkatd/storypad#297.

Moving the component was simple enough. The issue was placing the styles in a location that would get imported into the containing application (back into Storypad, in this specific case).

The only thing I've found that works is what we have now.

`share-modal.css` is placed into the `vendor` folder. Once there, we can import it from `index.js`. Several other addons do this same thing, albeit with third party styles, but I'm not sure if there's a better option. I'll keep looking, because I can't say I'm satisfied with the way this turned out, but this is what works for now.
