### PR TITLE
Added repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-gdrive",
   "version": "0.6.0",
+  "repository": "https://github.com/coderly/ember-gdrive",
   "devDependencies": {
     "brfs": "0.0.8",
     "ember-cli-simple-auth": "^0.7.1",


### PR DESCRIPTION
Resolves #48 

Nothing to comment on. The repository field inside `package.json` was missing, so warnings were being thrown during `npm` operations.