### PR TITLE
Added contentFor hook with gapi script injection to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 module.exports = {
   name: 'ember-gdrive',
+  
+  contentFor: function(type) {
+    if (type === 'head') {
+      return '<script type="text/javascript" src="https://apis.google.com/js/api.js"></script>';
+    }
+  },  
   included: function (app) {
     app.import('vendor/share-modal.css');
   }


### PR DESCRIPTION
Resolves #52

`contentFor` serves to inject content into the {{content-for 'head'}} and {{content-for 'body'}} tags in the application's index.html file.

It's supported from Ember-CLI 0.1.2 and onward, so applications that use the add-on with an older version of Ember-CLI should add the script tag manually. The add-on should work either way, since the `contentFor` hook will simply never be entered.