### PR TITLE
Resolve issue with breaking MapReference.isFor change in gapi

### DIFF
--- a/addon/lib/reference/map-reference.js
+++ b/addon/lib/reference/map-reference.js
@@ -23,10 +23,7 @@ var _serialize = function (object) {
 
 MapReference.isFor = function (data) {
   //return data instanceof gapi.drive.realtime.CollaborativeMap;
-  return data &&
-    data.hasOwnProperty('size') &&
-    data.hasOwnProperty('keys') &&
-    data.hasOwnProperty('values');
+  return data && data.type === 'Map';
 };
 
 // this is used for debugging purposes to get a snapshot of the Google Drive data structure


### PR DESCRIPTION
Resolves #56.

The change actually makes things simpler for us, for the time being, at least. These breaking changes are getting annoying, though.
