### PR TITLE
Made options parameter in session.authenticate optional

### DIFF
--- a/app/authenticators/gdrive.js
+++ b/app/authenticators/gdrive.js
@@ -22,6 +22,7 @@ var Authenticator = Base.extend({
 
   authenticate: function (options) {
     var authenticator = this;
+    options = options || {};
     return authenticator.get('auth').authorize(Ember.merge(options, { client_id: config.get('GOOGLE_CLIENT_ID') })).then(function () {
       return authenticator.get('auth').fetchCurrentUser();
     });


### PR DESCRIPTION
Resolves #59

I could also remove it completely, since we aren't using it for anything, but this way, the add-on user could pass in any gdrive option directly to the API if they need to.