### PR TITLE
Added check for FORBIDDEN error type in gapi

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -154,10 +154,9 @@ Document.reopenClass({
           throw new Error('Token refresh required');
         } else if(e.type === gapi.drive.realtime.ErrorType.CLIENT_ERROR) {
           throw new Error('An Error happened: ' + e.message);
-        } else if(e.type === gapi.drive.realtime.ErrorType.NOT_FOUND) {
+        } else if(e.type === gapi.drive.realtime.ErrorType.NOT_FOUND || e.type === gapi.drive.realtime.ErrorType.FORBIDDEN) {
           throw new Error('The file was not found. It does not exist or you do not have read access to the file.');
-        }
-        else {
+        } else {
           throw new Error('Unknown error occured.');
         }
       });


### PR DESCRIPTION
Resolves #64 

@venkatd: I decided to not go with an alert here. Since Ember supports using an error route/template, I decided to make use of that and use an approach similar to Storypad in our TodoMVC demo. There's a task and a pull request for that - begedin/ember-gdriveTodoMVC#35 and begedin/ember-gdriveTodoMVC#36.

What the actual issue was that it seems a new error type was at some point added to Google's API. From the code that was already there, it seems that it used to be that `NOT_FOUND` was the common error type for both missing documents as well as missing access rights. For access rights, we now have a new `FORBIDDEN` error type. For now I've bundled both under `NOT_FOUND`, so they return the same message, but in the future, we might want to look into more appropriate error handling, possibly with custom error types. I've created an issue for this - #72