### PR TITLE
Refactoring document creation process

### DIFF
--- a/addon/lib/document-source.js
+++ b/addon/lib/document-source.js
@@ -38,7 +38,7 @@ var DocumentSource = Ember.Object.extend({
     }
   },
   
-  createManually: function (title) {
+  createDocument: function (title) {
     var documentSource = this;
     if (!Ember.isEmpty(title)) {
       return Document.create({title: title}).then(function(doc) {

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -45,8 +45,6 @@ export default Ember.Mixin.create(ApplicationRouteMixin, {
   },
   
   transitionToDocument: function (doc) {
-    if (doc) {
-      this.transitionTo('document', doc);
-    }
+    this.transitionTo('document', doc);
   }
 });

--- a/app/components/document-creator.js
+++ b/app/components/document-creator.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
 
       this.set('isCreating', true);
 
-      return this.get('documentSource').createManually(title).then(function (doc) {
+      return this.get('documentSource').createDocument(title).then(function (doc) {
         component.sendAction('documentCreated', doc);
         component.set('isCreating', false);
       }, function (error) {


### PR DESCRIPTION
Resolves #76

I've renamed the `createManually` method to `createDocument`, since I do agree it makes things clearer.

As for the `if (doc)` check upon document creation/loading, as far as I can tell, a case where `doc` is `undefined` or `null` is not possible. If there's an issue with creating or loading the document, the request will be rejected instead. 

Even if there is a case where document is `null` or `undefined`, in my opinion, letting the app throw an error would be a better choice, since in that case, the built-in Ember error handling will output the error to the user.