### PR TITLE
Changed the way documentId is parsed from location.href

### DIFF
--- a/app/authenticators/gdrive.js
+++ b/app/authenticators/gdrive.js
@@ -41,7 +41,7 @@ var Authenticator = Base.extend({
   },
   
   getDocumentIdFromLocation: function () {
-    return location.href.split('/#/d/')[1].split('/')[0];
+    return location.href.split('/d/')[1].split('/')[0];
   },
   
   inferUserId: function() {


### PR DESCRIPTION
Resolves #84.

The new way works with `locationType` set to either `'hash'` and `'auto'`/`'none'`.