### PR TITLE
Added alert upon error during document deletion

### DIFF
--- a/addon/components/share-modal.js
+++ b/addon/components/share-modal.js
@@ -105,6 +105,7 @@ export default Ember.Component.extend({
       permission.save().then(null, function (error) {
         permission.rollback();
         Ember.run.once(component, component.loadData, null);
+        alert(error.message);
       });
     }
   },


### PR DESCRIPTION
This informs the user if there's an error during deletion attempt. Among other things, it resolves #85, since gapi does throw a specific error when the user attempts to remove their own access rights from a document.