### PR TITLE
Removed ember-cli-simple-auth dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "ember-cli-6to5": "0.2.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-simple-auth": "^0.7.1",
     "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",


### PR DESCRIPTION
Due to the fact that `ember-cli-simple-auth` doesn't account for being loaded from another addon, so there is no use having it as an `ember-gdrive` dependency. It actually just needs to be installed to the parent app together with `ember-gdrive` via the default blueprint instead.

If there's ever an update to `ember-cli-simple-auth` that would make it work via nesting, then we can move it back here, but for now, it's completely redundant and does nothing.

This is the only thing that ended up being needed to resolve #79.