### PR TITLE
Updated handlebars to ~2.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.6.0",
   "description": "Google Drive bindings for Ember Data",
   "dependencies": {  
-    "handlebars": "~1.3.0",
+    "handlebars": "~2.0.0",
     "jquery": "^1.11.1",
     "ember": "1.8.1",
     "ember-data": "1.0.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/coderly/ember-gdrive",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "broccoli-ember-hbs-template-compiler": "^1.6.1",
+    "ember-cli-htmlbars": "^0.5.3",
     "ember-cli": "0.1.7",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",


### PR DESCRIPTION
Resolves #92.

An update to handlebars also requires replacing `broccoli-ember-hbs-template-compiler` with `ember-cli-htmlbars`.

As far as I can tell, there are no breaking changes, since the templates we use are relatively simple. I did some testing and there were no problems I could find.