### PR TITLE
Added more verbose error messages related to incorrect or missing configuration

### DIFF
--- a/addon/lib/config.js
+++ b/addon/lib/config.js
@@ -5,12 +5,36 @@ var Config = Ember.Object.extend({
   GOOGLE_MIME_TYPE: null,
   GOOGLE_DRIVE_SDK_APP_ID: null,
   GOOGLE_CLIENT_ID: null,
-  
+
   load: function (configuration) {
-    this.set('GOOGLE_API_KEY', configuration.GOOGLE_API_KEY);
-    this.set('GOOGLE_MIME_TYPE', configuration.GOOGLE_MIME_TYPE);
-    this.set('GOOGLE_DRIVE_SDK_APP_ID', configuration.GOOGLE_DRIVE_SDK_APP_ID);
-    this.set('GOOGLE_CLIENT_ID', configuration.GOOGLE_CLIENT_ID);
+    if (configuration) {
+      if (configuration.GOOGLE_API_KEY) {
+        this.set('GOOGLE_API_KEY', configuration.GOOGLE_API_KEY);
+      } else {
+        throw new Error('The GOOGLE_API_KEY configuration property has not been set.');
+      }
+      
+      if (configuration.GOOGLE_MIME_TYPE) {
+        this.set('GOOGLE_MIME_TYPE', configuration.GOOGLE_MIME_TYPE);
+      } else {
+        throw new Error('The GOOGLE_MIME_TYPE configuration property has not been set.');
+      }
+      
+      if (configuration.GOOGLE_DRIVE_SDK_APP_ID) {
+        this.set('GOOGLE_DRIVE_SDK_APP_ID', configuration.GOOGLE_DRIVE_SDK_APP_ID);
+      } else {
+        throw new Error('The GOOGLE_DRIVE_SDK_APP_ID configuration property has not been set.');
+      }
+
+      
+      if (configuration.GOOGLE_CLIENT_ID) {
+        this.set('GOOGLE_CLIENT_ID', configuration.GOOGLE_CLIENT_ID);
+      } else {
+        throw new Error('The GOOGLE_CLIENT_ID configuration property has not been set.');
+      }
+    } else {
+      throw new Error('The \'ember-gdrive\' configuration group is not present. Please add a configuration group containing the Google API information to your application configuration\'s \'ENV.APP\' object.');
+    }
   }
 });
 


### PR DESCRIPTION
Should resolve #100.

Includes 5 separate error messages inside `addon\lib\config`
* 1 for entire `ember-gdrive` configuration group missing
* 1 for each of the individual 4 properties missing