### PR TITLE
Add gapi config placeholder via blueprint

### DIFF
--- a/blueprints/ember-gdrive/index.js
+++ b/blueprints/ember-gdrive/index.js
@@ -7,6 +7,14 @@ module.exports = {
 
   afterInstall: function (options) {
     var addonContext = this;
+    
+    this.insertIntoFile('config/environment.js', 
+        '\n      \'ember-gdrive\': {' +
+        '\n        GOOGLE_API_KEY: \'<insert here>\',' +
+        '\n        GOOGLE_MIME_TYPE: \'application/\',' +
+        '\n        GOOGLE_DRIVE_SDK_APP_ID: \'<insert here>\',' +
+        '\n        GOOGLE_CLIENT_ID: \'<insert here>\'' + 
+        '\n      },\n' , { after: 'APP: {' });
 
     return this.addBowerPackageToProject('ember-simple-auth', '~0.7.2')
       .then(function () {

--- a/blueprints/ember-gdrive/index.js
+++ b/blueprints/ember-gdrive/index.js
@@ -7,17 +7,19 @@ module.exports = {
 
   afterInstall: function (options) {
     var addonContext = this;
-    
-    this.insertIntoFile('config/environment.js', 
-        '\n      \'ember-gdrive\': {' +
-        '\n        GOOGLE_API_KEY: \'<insert here>\',' +
-        '\n        GOOGLE_MIME_TYPE: \'application/\',' +
-        '\n        GOOGLE_DRIVE_SDK_APP_ID: \'<insert here>\',' +
-        '\n        GOOGLE_CLIENT_ID: \'<insert here>\'' + 
-        '\n      },\n' , { after: 'APP: {' });
 
-    return this.addBowerPackageToProject('ember-simple-auth', '~0.7.2')
+    this.insertIntoFile('config/environment.js',
+      '\n      \'ember-gdrive\': {' +
+      '\n        GOOGLE_API_KEY: \'<insert here>\',' +
+      '\n        GOOGLE_MIME_TYPE: \'application/<insert here>\',' +
+      '\n        GOOGLE_DRIVE_SDK_APP_ID: \'<insert here>\',' +
+      '\n        GOOGLE_CLIENT_ID: \'<insert here>\'' +
+      '\n      },\n', {
+        after: 'APP: {'
+      })
       .then(function () {
+        return this.addBowerPackageToProject('ember-simple-auth', '~0.7.2');
+      }).then(function () {
         return addonContext.addAddonToProject('ember-cli-simple-auth', '~0.7.2');
       });
   }


### PR DESCRIPTION
Should resolve #103 

Sadly, it's not as simple as I hoped.

**While the code works**, there are a few issues.

## Issues

1. Technically, the `insertIntoFile` method checks if the string we're inserting is already present in the file. This generally works, but it literally searches for that exact string. Two problems come from this.
  * Any change in formatting will cause the string to not be detected, so repeated calls for `ember install:addon`will re-add the same string
  * Actually adding the proper settings in place of the placeholder will cause the same behavior when repeatedly calling `ember install:addon`.

  I guess neither should really happen in a proper case, but there's really very little we can do about it anyway, since it's purely a file writing approach we're using here, with no script/object/json parsing or anything similarly more robust.

2. Since it's a multi-line string, the formatting is kind of ugly. This probably isn't a huge issue, since once it's written down, there's little reason to change it.

3. It expects the structure of `config/environment` to be the default structure that Ember-CLI creates, meaning indentations are assumed to be as they are. If the user restructures the file, the formatting will be kind of wrong, though it will still be inserted at the proper place in the code.

## Options

* This is basically node code that's running here and the entirety of index.js get's executed in a node environment, so I could look into and make use of some node modules to make this more robust. I'm really not that familiar with node to now for sure what could be done, so this is just a guess and will require research.

* Outside of that, we can hope that there will be a more robust approach in the future.

* I could also go with something along the lines of skipping the `insertIntoFile` method. Instead, I could do the following:
  * Read the entire file
  * `JSON.parse()` the file
  * Add our properties into the parsed object
  * `JSON.stringify()` it again, fix the formatting and overwrite the old file

  This would probably be overkill, though.