### PR TITLE
Implemented auto-adding required ContentSecurityPolicy rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,38 @@ module.exports = {
     if (type === 'head') {
       return '<script type="text/javascript" src="https://apis.google.com/js/api.js"></script>';
     }
+  },
+  
+  config: function (environment, baseConfig) {
+    
+    var config = {};
+    
+    config.contentSecurityPolicyHeader = 'Content-Security-Policy';
+    config.contentSecurityPolicy = baseConfig.contentSecurityPolicy || {};
+    var requiredCSP = {
+      'default-src': 'accounts.google.com content.googleapis.com drive.google.com',
+      'script-src': '\'unsafe-eval\' \'unsafe-inline\' apis.google.com drive.google.com',
+      'connect-src': '\'unsafe-eval\' apis.google.com drive.google.com',
+      'img-src': 'data: ssl.gstatic.com csi.gstatic.com',
+      'style-src': '\'unsafe-inline\''
+    };
+    
+    if (config.contentSecurityPolicy['default-src'] === '\'none\'') {
+      config.contentSecurityPolicy['default-src'] = '';
+    }
+    
+    var mergeValues = function (item) {
+      if (!config.contentSecurityPolicy[propertyName]) {
+        config.contentSecurityPolicy[propertyName] = item;
+      } else if (config.contentSecurityPolicy[propertyName].indexOf(item) === -1) {
+        config.contentSecurityPolicy[propertyName] += ' ' + item;
+      }
+    };
+    
+    for (var propertyName in requiredCSP) {
+      requiredCSP[propertyName].split(' ').forEach(mergeValues);
+    }
+    
+    return config;
   }
 };


### PR DESCRIPTION
Will resolve #101 

I decided to go with option 3 just to show you what I mean, but now that I have it (and it works properly), I'm thinking this might be considered bad add-on behavior, since it basically opens up potential security issues without the user actually knowing this.

To elaborate, this will not change `config\environment.js` physically on the disk. Instead, it will add the rules required by the add-on into the config object in memory. It's way more robust than option 2 in the issue description, but as I said, there may be a security concern.

On the other hand, option 2 is more transparent, but also much less robust. It has to deal with all the same issues that pull request #106 has listed, slightly increased by the fact that there's more text to add in this one. That being said, I'm also leaning towards option 2 now and it should be a quick thing to abandon the current approach and implement it that way.