### PR TITLE
Moved share-modal bound actions to document controller

### DIFF
--- a/blueprints/ember-gdrive/files/app/controllers/document.js
+++ b/blueprints/ember-gdrive/files/app/controllers/document.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+
+  isSharing: false,
+  
+  actions: {
+    share: function () {
+      this.set('isSharing', true);
+    }
+    
+  }
+});

--- a/blueprints/ember-gdrive/files/app/controllers/items.js
+++ b/blueprints/ember-gdrive/files/app/controllers/items.js
@@ -14,8 +14,6 @@ export default Ember.ArrayController.extend({
     
     delete: function (item) {
       item.destroyRecord();
-    },
-    
-    
+    }
   }
 });

--- a/blueprints/ember-gdrive/files/app/routes/document.js
+++ b/blueprints/ember-gdrive/files/app/routes/document.js
@@ -1,11 +1,4 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-gdrive/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  isSharing: false,
-  actions: {
-    share: function () {
-      this.set('isSharing', true);
-    }
-  }
-});
+export default Ember.Route.extend(AuthenticatedRouteMixin, {});


### PR DESCRIPTION
Resolves #119.

This fixes the share modal not working in the default blueprint. For some reason, placing the action and the bound property into the document route doesn't work. The action triggers, but the binding inside the share-modal component does not.