### PR TITLE
Added loader partial to be used in document-creator and share-modal

### DIFF
--- a/app/templates/components/document-creator.hbs
+++ b/app/templates/components/document-creator.hbs
@@ -1,6 +1,7 @@
 <h3>Create a document</h3>
 {{#if isCreating}}
   Creating document...
+  {{partial 'loader'}}
 {{else}}
   {{input type="text" value=documentTitle insert-newline="createDocument" placeholder="Type document name here"}}
   <button {{action 'createDocument'}}>Create</button>

--- a/app/templates/components/share-modal.hbs
+++ b/app/templates/components/share-modal.hbs
@@ -8,6 +8,7 @@
   <div class="share-modal-content">
     {{#unless isLoaded}}
       <em>Retrieving data...</em>
+      {{partial 'loader'}}
     {{/unless}} 
     {{#if showError}}
       <em>Error retrieving permissions for this document.</em>

--- a/app/templates/loader.hbs
+++ b/app/templates/loader.hbs
@@ -1,0 +1,1 @@
+<div class="loader"></div>

--- a/index.js
+++ b/index.js
@@ -41,5 +41,6 @@ module.exports = {
   },  
   included: function (app) {
     app.import('vendor/share-modal.css');
+    app.import('vendor/loader.css');
   }
 };

--- a/vendor/loader.css
+++ b/vendor/loader.css
@@ -1,0 +1,29 @@
+.loader {
+  width: 40px;
+  height: 40px;
+  margin: 100px auto;
+  background-color: #333;
+
+  border-radius: 100%;  
+  -webkit-animation: scaleout 1.0s infinite ease-in-out;
+  animation: scaleout 1.0s infinite ease-in-out;
+}
+
+@-webkit-keyframes scaleout {
+  0% { -webkit-transform: scale(0.0) }
+  100% {
+    -webkit-transform: scale(1.0);
+    opacity: 0;
+  }
+}
+
+@keyframes scaleout {
+  0% { 
+    transform: scale(0.0);
+    -webkit-transform: scale(0.0);
+  } 100% {
+    transform: scale(1.0);
+    -webkit-transform: scale(1.0);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Resolves #109 and #110

I used a relatively simple CSS style which requires a single div with a specific class. It was the second one on the following link: http://tobiasahlin.com/spinkit/

Properties to indicate that data is currently loading were already present in both `document-creator` and `share-modal`, so it was just a matter of adding the new loader partial into the proper `#if` scope.

I'm thinking this should be good enough for now. In the future, the user would be able to provide their own content for both components through the use of `{{yield}}` and we can improve on the look when there's time and we have something concrete to use.
