### PR TITLE
Removed automatic filling-out of content security policy

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,38 +7,6 @@ module.exports = {
     }
   },
   
-  config: function (environment, baseConfig) {
-    
-    var config = {};
-    
-    config.contentSecurityPolicyHeader = 'Content-Security-Policy';
-    config.contentSecurityPolicy = baseConfig.contentSecurityPolicy || {};
-    var requiredCSP = {
-      'default-src': 'accounts.google.com content.googleapis.com drive.google.com',
-      'script-src': '\'unsafe-eval\' \'unsafe-inline\' apis.google.com drive.google.com',
-      'connect-src': '\'unsafe-eval\' apis.google.com drive.google.com',
-      'img-src': 'data: ssl.gstatic.com csi.gstatic.com',
-      'style-src': '\'unsafe-inline\''
-    };
-    
-    if (config.contentSecurityPolicy['default-src'] === '\'none\'') {
-      config.contentSecurityPolicy['default-src'] = '';
-    }
-    
-    var mergeValues = function (item) {
-      if (!config.contentSecurityPolicy[propertyName]) {
-        config.contentSecurityPolicy[propertyName] = item;
-      } else if (config.contentSecurityPolicy[propertyName].indexOf(item) === -1) {
-        config.contentSecurityPolicy[propertyName] += ' ' + item;
-      }
-    };
-    
-    for (var propertyName in requiredCSP) {
-      requiredCSP[propertyName].split(' ').forEach(mergeValues);
-    }
-    
-    return config;
-  },  
   included: function (app) {
     app.import('vendor/share-modal.css');
   }


### PR DESCRIPTION
Related to/resolves #101

What we did in #107 doesn't actually work.

That is, it works if the user has no need to add their own ContentSecurityPolicy rules, but if they do (due to, for instance, using additional 3rd party components that require it), then the user's rules will overwrite those we set in the add-on.

Due to that, I believe, and I explained it in https://github.com/coderly/ember-gdrive/issues/101#issuecomment-72719123, that we should abandon this attempt and not touch the ContentSecurityPolicy settings.

Instead, we should link to proper documentation regarding this feature in the README and also list the required settings in order to avoid warnings being thrown.

The result of that is that by the default, the app using ember-gdrive will run without functional issues but throw warnings in the console due to content security policy violations. If the user of the add-on want's to get rid of these warnings, they will have all the information they need, in order to do so.

This is what this PR does.

Arguments for this "solution":
1. [ContentSecurityPolicy is something that we're concerning ourselves during development](https://github.com/rwjblue/ember-cli-content-security-policy#ember-cli-content-security-policy), not during production.
2. Modifying these settings might actually be considered bad addon behavior.
3. Having just the default settings doesn't break the app, it just throws ugly-looking console warnings.
