### PR TITLE
Refactored login hint process

### DIFF
--- a/addon/lib/auth.js
+++ b/addon/lib/auth.js
@@ -5,6 +5,8 @@ var INSTALL_SCOPE = 'https://www.googleapis.com/auth/drive.install',
 
 import Ember from 'ember';
 import loader from 'ember-gdrive/lib/loader';
+import { fetchLoginHint } from 'ember-gdrive/lib/login-hint';
+import config from 'ember-gdrive/lib/config';
 
 var merge = function(a, b) {
   return Ember.merge(a || {}, b || {});
@@ -22,6 +24,8 @@ var Auth = Ember.Object.extend({
     var finalOptions = merge({
       scope: this.permissions,
       authuser: -1,
+      login_hint: fetchLoginHint(),
+      client_id: config.get('GOOGLE_CLIENT_ID'),
       immediate: false
     }, options || {});
 

--- a/addon/lib/auth.js
+++ b/addon/lib/auth.js
@@ -24,7 +24,6 @@ var Auth = Ember.Object.extend({
     var finalOptions = merge({
       scope: this.permissions,
       authuser: -1,
-      login_hint: fetchLoginHint(),
       client_id: config.get('GOOGLE_CLIENT_ID'),
       immediate: false
     }, options || {});
@@ -46,8 +45,9 @@ var Auth = Ember.Object.extend({
 
   authorizeImmediate: function(options) {
     return this.authorize(merge({
+      login_hint: fetchLoginHint(),
       immediate: true
-    }, options));
+    }, options || {}));
   },
 
   fetchCurrentUser: function() {

--- a/addon/lib/login-hint.js
+++ b/addon/lib/login-hint.js
@@ -26,4 +26,4 @@ function _getDocumentIdFromLocation() {
   return location.href.split('/d/')[1].split('/')[0];
 }
 
-export default { cacheLoginHint, fetchLoginHint };
+export { cacheLoginHint, fetchLoginHint };

--- a/addon/lib/login-hint.js
+++ b/addon/lib/login-hint.js
@@ -1,0 +1,29 @@
+import Cache from 'ember-gdrive/lib/local-cache';
+
+function cacheLoginHint(documentId, userId) {
+  var cache = new Cache('document_login_hint');
+  cache.set(documentId, userId);
+}
+
+function fetchLoginHint() {
+  var userId = _extractQueryParams().userId;
+  if (!userId) {
+    var cache = new Cache('document_login_hint');
+    userId = cache.get(_getDocumentIdFromLocation());
+  }
+  return userId;
+}
+
+function _extractQueryParams() {
+  var params = {};
+  location.search.substr(1).split('&').forEach(function (item) {
+    params[item.split('=')[0]] = decodeURIComponent(item.split('=')[1]);
+  });
+  return params.state ? JSON.parse(params.state) : {};
+}
+
+function _getDocumentIdFromLocation() {
+  return location.href.split('/d/')[1].split('/')[0];
+}
+
+export default { cacheLoginHint, fetchLoginHint };

--- a/addon/lib/login-hint.js
+++ b/addon/lib/login-hint.js
@@ -1,4 +1,5 @@
 import Cache from 'ember-gdrive/lib/local-cache';
+import { extractQueryParams } from 'ember-gdrive/lib/uri';
 
 function cacheLoginHint(documentId, userId) {
   var cache = new Cache('document_login_hint');
@@ -6,20 +7,12 @@ function cacheLoginHint(documentId, userId) {
 }
 
 function fetchLoginHint() {
-  var userId = _extractQueryParams().userId;
+  var userId = extractQueryParams().userId;
   if (!userId) {
     var cache = new Cache('document_login_hint');
     userId = cache.get(_getDocumentIdFromLocation());
   }
   return userId;
-}
-
-function _extractQueryParams() {
-  var params = {};
-  location.search.substr(1).split('&').forEach(function (item) {
-    params[item.split('=')[0]] = decodeURIComponent(item.split('=')[1]);
-  });
-  return params.state ? JSON.parse(params.state) : {};
 }
 
 function _getDocumentIdFromLocation() {

--- a/addon/lib/login-hint.js
+++ b/addon/lib/login-hint.js
@@ -1,5 +1,5 @@
 import Cache from 'ember-gdrive/lib/local-cache';
-import { extractQueryParams } from 'ember-gdrive/lib/uri';
+import { extractQueryParams, getDocumentIdFromLocation } from 'ember-gdrive/lib/uri';
 
 function cacheLoginHint(documentId, userId) {
   var cache = new Cache('document_login_hint');
@@ -10,13 +10,10 @@ function fetchLoginHint() {
   var userId = extractQueryParams().userId;
   if (!userId) {
     var cache = new Cache('document_login_hint');
-    userId = cache.get(_getDocumentIdFromLocation());
+    userId = cache.get(getDocumentIdFromLocation());
   }
   return userId;
 }
 
-function _getDocumentIdFromLocation() {
-  return location.href.split('/d/')[1].split('/')[0];
-}
 
 export { cacheLoginHint, fetchLoginHint };

--- a/addon/lib/uri.js
+++ b/addon/lib/uri.js
@@ -1,4 +1,4 @@
-var extractQueryParams = function() {
+function extractQueryParams() {
   var params = {};
   location.search.substr(1).split('&').forEach(function(item) {
     params[item.split('=')[0]] = decodeURIComponent(item.split('=')[1]);
@@ -6,7 +6,7 @@ var extractQueryParams = function() {
   return params;
 };
 
-var clearQueryString = function() {
+function clearQueryString() {
   var uri = window.location.toString();
   if (uri.indexOf('?') > 0) {
     var cleanUri = uri.substring(0, uri.indexOf('?'));
@@ -14,4 +14,8 @@ var clearQueryString = function() {
   }
 };
 
-export { extractQueryParams, clearQueryString };
+function getDocumentIdFromLocation() {
+  return location.href.split('/d/')[1].split('/')[0];
+}
+
+export { extractQueryParams, clearQueryString, getDocumentIdFromLocation };

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -11,20 +11,17 @@ export default Ember.Mixin.create(ApplicationRouteMixin, {
     var state = documentSource.get('state'); // Forces creation of the state, which clears the query params
     var isStatePresent = state.get('isOpen') || state.get('isCreate');
 
-    if (!isStatePresent) {
-      return;
+    if (isStatePresent) {
+      this.get('session').authenticate('authenticator:gdrive', { 'login_hint': state.get('userID') }).then(function () {
+        if (state.get('isOpen')) {
+          return documentSource.openFromState();
+        } else {
+          return documentSource.createFromState();
+        }
+      }).then(function (doc) {
+          route.transitionToDocument(doc);
+      });
     }
-
-    this.get('session').authenticate('authenticator:gdrive').then(function () {
-
-      if (state.get('isOpen')) {
-        return documentSource.openFromState();
-      } else {
-        return documentSource.createFromState();
-      }
-    }).then(function (doc) {
-        route.transitionToDocument(doc);
-    });
   },
 
   actions: {

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -4,13 +4,12 @@ import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixi
 
 export default Ember.Mixin.create(AuthenticatedRouteMixin, {
   model: function (params) {
-    var route = this;
+    return this.get('documentSource').load(params.document_id);
+  },
 
-    return this.get('documentSource').load(params.document_id).then(function (doc) {
-      var userId = route.get('session.id');
-      var documentId = route.get('documentSource.document.id');
-      cacheLoginHint(documentId, userId);
-      return doc;
-    });
+  afterModel: function (document, transition) {
+    var userId = this.get('session.secure.id');
+    var documentId = this.get('documentSource.id');
+    cacheLoginHint(documentId, userId);
   }
 });

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -4,9 +4,11 @@ import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixi
 
 export default Ember.Mixin.create(AuthenticatedRouteMixin, {
   model: function (params) {
+    var route = this;
+
     return this.get('documentSource').load(params.document_id).then(function (doc) {
-      var userId = this.get('session.id');
-      var documentId = this.get('documentSource.document.id');
+      var userId = route.get('session.id');
+      var documentId = route.get('documentSource.document.id');
       cacheLoginHint(documentId, userId);
       return doc;
     });

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -1,21 +1,14 @@
 import Ember from 'ember';
-import Cache from 'ember-gdrive/lib/local-cache';
+import { cacheLoginHint } from 'ember-gdrive/lib/login-hint';
 import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Mixin.create(AuthenticatedRouteMixin, {
-  cacheLoginHint: function() {
-    var userId = this.get('session.id');
-    var docId = this.get('documentSource.document.id');
-    var cache = new Cache('document_login_hint');
-
-    cache.set(docId, userId);
-  },
-
   model: function (params) {
-      var route = this;
-      return this.get('documentSource').load(params.document_id).then(function (doc) {
-        route.cacheLoginHint();
-        return doc;
-      });
+    return this.get('documentSource').load(params.document_id).then(function (doc) {
+      var userId = this.get('session.id');
+      var documentId = this.get('documentSource.document.id');
+      cacheLoginHint(documentId, userId);
+      return doc;
+    });
   }
 });

--- a/app/authenticators/gdrive.js
+++ b/app/authenticators/gdrive.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Base from 'simple-auth/authenticators/base';
 import Auth from 'ember-gdrive/lib/auth';
-import Cache from 'ember-gdrive/lib/local-cache';
+import { fetchLoginHint } from 'ember-drive/lib/login-hint';
 import config from 'ember-gdrive/lib/config';
 
 var Authenticator = Base.extend({
@@ -13,7 +13,7 @@ var Authenticator = Base.extend({
   restore: function (properties) {
     var authenticator = this;
     return authenticator.get('auth').authorizeImmediate({
-      login_hint: this.inferUserId(),
+      login_hint: fetchLoginHint(),
       client_id: config.get('GOOGLE_CLIENT_ID')
     }).then(function () {
       return authenticator.get('auth').fetchCurrentUser();
@@ -30,27 +30,6 @@ var Authenticator = Base.extend({
 
   invalidate: function () {
     return this.get('auth').close();
-  },
-
-  extractQueryParams: function () {
-    var params = {};
-    location.search.substr(1).split('&').forEach(function (item) {
-      params[item.split('=')[0]] = decodeURIComponent(item.split('=')[1]);
-    });
-    return params.state ? JSON.parse(params.state) : {};
-  },
-
-  getDocumentIdFromLocation: function () {
-    return location.href.split('/d/')[1].split('/')[0];
-  },
-
-  inferUserId: function() {
-    var userId = this.extractQueryParams().userId;
-    if (!userId) {
-      var cache = new Cache('document_login_hint');
-      userId = cache.get(this.getDocumentIdFromLocation());
-    }
-    return userId;
   }
 });
 

--- a/app/authenticators/gdrive.js
+++ b/app/authenticators/gdrive.js
@@ -1,8 +1,5 @@
-import Ember from 'ember';
 import Base from 'simple-auth/authenticators/base';
 import Auth from 'ember-gdrive/lib/auth';
-import { fetchLoginHint } from 'ember-gdrive/lib/login-hint';
-import config from 'ember-gdrive/lib/config';
 
 var Authenticator = Base.extend({
 
@@ -12,10 +9,7 @@ var Authenticator = Base.extend({
 
   restore: function (properties) {
     var authenticator = this;
-    return authenticator.get('auth').authorizeImmediate({
-      login_hint: fetchLoginHint(),
-      client_id: config.get('GOOGLE_CLIENT_ID')
-    }).then(function () {
+    return authenticator.get('auth').authorizeImmediate().then(function () {
       return authenticator.get('auth').fetchCurrentUser();
     });
   },
@@ -23,7 +17,7 @@ var Authenticator = Base.extend({
   authenticate: function (options) {
     var authenticator = this;
     options = options || {};
-    return authenticator.get('auth').authorize(Ember.merge(options, { client_id: config.get('GOOGLE_CLIENT_ID') })).then(function () {
+    return authenticator.get('auth').authorize(options).then(function () {
       return authenticator.get('auth').fetchCurrentUser();
     });
   },

--- a/app/authenticators/gdrive.js
+++ b/app/authenticators/gdrive.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Base from 'simple-auth/authenticators/base';
 import Auth from 'ember-gdrive/lib/auth';
-import { fetchLoginHint } from 'ember-drive/lib/login-hint';
+import { fetchLoginHint } from 'ember-gdrive/lib/login-hint';
 import config from 'ember-gdrive/lib/config';
 
 var Authenticator = Base.extend({

--- a/design_notes.md
+++ b/design_notes.md
@@ -1,0 +1,10 @@
+# create file
+
+`'?state=%7B%22folderId%22:%220AMftiYAzT3YQUk9PVA%22,%22action%22:%22create%22,%22userId%22:%22#{user_id}%22%7D'`
+
+* When you login using one of the demo apps (storypad ot todoMVC, there will be a network request titled userInfo, which contains the user id)
+
+# open file
+`'?state=%7B%22ids%22:%5B%22{document_id_goes_here}%22%5D,%22action%22:%22open%22,%22userId%22:%22#{user_id}%22%7D'`
+
+* If you don't have a specific document to open, then creating a new one will give you an id

--- a/design_notes.md
+++ b/design_notes.md
@@ -1,10 +1,10 @@
 # create file
 
-`'?state=%7B%22folderId%22:%220AMftiYAzT3YQUk9PVA%22,%22action%22:%22create%22,%22userId%22:%22#{user_id}%22%7D'`
+`'?state=%7B%22folderId%22:%220AMftiYAzT3YQUk9PVA%22,%22action%22:%22create%22,%22userId%22:%22{user_id}%22%7D'`
 
 * When you login using one of the demo apps (storypad ot todoMVC, there will be a network request titled userInfo, which contains the user id)
 
 # open file
-`'?state=%7B%22ids%22:%5B%22{document_id_goes_here}%22%5D,%22action%22:%22open%22,%22userId%22:%22#{user_id}%22%7D'`
+`'?state=%7B%22ids%22:%5B%22{document_id_goes_here}%22%5D,%22action%22:%22open%22,%22userId%22:%22{user_id}%22%7D'`
 
 * If you don't have a specific document to open, then creating a new one will give you an id

--- a/design_notes.txt
+++ b/design_notes.txt
@@ -1,5 +1,0 @@
-create file
-?state=%7B%22folderId%22:%220AMftiYAzT3YQUk9PVA%22,%22action%22:%22create%22,%22userId%22:%117742084218787125292%22%7D
-
-open file
-?state=%7B%22ids%22:%5B%220B8ftiYAzT3YQcDc5V3RScjl3OU0%22%5D,%22action%22:%22open%22,%22userId%22:%22117742084218787125292%22%7D


### PR DESCRIPTION
Hopefully resolves #130 

Regarding the `createFromState` and `openFromState` methods, they are already implemented and seem to be working fine. The thing that did seem to change are the parameters we need to send through the URL. I updated the design_notes.txt (replaced wth an .md) with an explanation how to form the URL exactly.

Regarding extraction of `cacheLoginHint` into a library, I went a step further and also extracted the methods required for login hint retrieval (used in the authenticator) into the same library. This way, we keep that logic in one place.
